### PR TITLE
Simplified test command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ jobs:
             CONTACTS_DB_URL: "postgres://root@localhost:5432/circle_test?sslmode=disable"
             CONTACTS_DB_MIGRATIONS: /go/src/github.com/CircleCI-Public/circleci-demo-go/db/migrations
           command: |
-            trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
             make test | tee ${TEST_RESULTS}/go-test.out
+            go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml
 
       - run: make
 


### PR DESCRIPTION
I've stumbled upon this when implementing CI in my project, to me it looked like there's no reason to use the trap command, which would simplify the command and make the order easier to understand.

If I did miss something and the trap command is needed, throw the PR away :-)