### PR TITLE
Demonstrate test splitting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ jobs: # basic units of work in a run
           POSTGRES_USER: circleci-demo-go
           POSTGRES_DB: circle_test
 
+    parallelism: 2
+
     environment: # environment variables for the build itself
       TEST_RESULTS: /tmp/test-results # path to where test results will be saved
 
@@ -26,13 +28,6 @@ jobs: # basic units of work in a run
           command: |
             go get -v
 
-      - run: 
-          name: Get go-junit-report for setting up test timings on CircleCI
-          command: |
-            go get github.com/jstemmer/go-junit-report
-            # Remove go-junit-report from go.mod
-            go mod tidy
-
       #  Wait for Postgres to be ready before proceeding
       - run:
           name: Waiting for Postgres to be ready
@@ -46,8 +41,8 @@ jobs: # basic units of work in a run
 
           # store the results of our tests in the $TEST_RESULTS directory
           command: |
-            trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
-            make test | tee ${TEST_RESULTS}/go-test.out
+            PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
+            gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- $PACKAGE_NAMES
 
       - run: make # pull and build dependencies for the project
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 GOFILES = $(shell find . -name '*.go')
-GOPACKAGES = $(shell go list ./...)
 
 default: build
 
@@ -13,8 +12,3 @@ build-native: $(GOFILES)
 
 workdir/contacts: $(GOFILES)
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o workdir/contacts .
-
-test: test-all
-
-test-all:
-	@go test -v $(GOPACKAGES)

--- a/bigdata/processor.go
+++ b/bigdata/processor.go
@@ -1,0 +1,15 @@
+package bigdata
+
+import (
+	"time"
+)
+
+func DoComputation() bool {
+	time.Sleep(5 * time.Second)
+	return true
+}
+
+func DoComplexComputation() bool {
+	time.Sleep(10 * time.Second)
+	return true
+}

--- a/bigdata/processor_test.go
+++ b/bigdata/processor_test.go
@@ -1,0 +1,17 @@
+package bigdata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDoComputation(t *testing.T) {
+	result := DoComputation()
+	assert.True(t, result)
+}
+
+func TestDoComplexComputation(t *testing.T) {
+	result := DoComplexComputation()
+	assert.True(t, result)
+}

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,0 +1,5 @@
+package formatter
+
+func Format(input string) string {
+	return "Formatted: " + input
+}

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -1,0 +1,12 @@
+package formatter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormat(t *testing.T) {
+	result := Format("my string")
+	assert.Equal(t, result, "Formatted: my string")
+}

--- a/math/sum.go
+++ b/math/sum.go
@@ -1,0 +1,5 @@
+package math
+
+func Sum(x int, y int) int {
+	return x + y
+}

--- a/math/sum_test.go
+++ b/math/sum_test.go
@@ -1,0 +1,23 @@
+package math
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSumPositive(t *testing.T) {
+	total := Sum(1, 1)
+	assert.Equal(t, total, 2)
+}
+func TestSumNegative(t *testing.T) {
+	total := Sum(1, -10)
+	assert.Equal(t, total, -9)
+}
+
+func TestSumLarge(t *testing.T) {
+	time.Sleep(5 * time.Second)
+	total := Sum(10000, 10000)
+	assert.Equal(t, total, 20000)
+}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,0 +1,5 @@
+package validator
+
+func Validate(input string) bool {
+	return true
+}

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -1,0 +1,12 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidate(t *testing.T) {
+	result := Validate("my string")
+	assert.True(t, result)
+}


### PR DESCRIPTION
Add more tests and parallelism in order to demo test splitting
Use gotestsum 0.34 to generate the result in junit xml format instead of go-junit-report, as the testcase classname value in junit xml generated by gotestsum is the fully qualified package name as required for the circleci tests split command to be able to look up the historical test timings. (Note: versions earlier than 0.34 do not output the fully qualified package name)